### PR TITLE
[BugFix] multiple definition of `_Z11getUniqueIdv'

### DIFF
--- a/lib/EspSimHub/EspSimHub.cpp
+++ b/lib/EspSimHub/EspSimHub.cpp
@@ -1,0 +1,6 @@
+#include <EspSimHub.h>
+
+String getUniqueId()
+{
+    return WiFi.macAddress();
+}

--- a/lib/EspSimHub/EspSimHub.h
+++ b/lib/EspSimHub/EspSimHub.h
@@ -14,7 +14,4 @@
 //  in the future we could use the bytes to generate some
 //  other format (ala UUID), but now it's just a unique
 //  string tied to the device.
-String getUniqueId()
-{
-    return WiFi.macAddress();
-}
+String getUniqueId();

--- a/lib/TcpSerialBridge/TcpSerialBridge.cpp
+++ b/lib/TcpSerialBridge/TcpSerialBridge.cpp
@@ -20,7 +20,7 @@ TcpSerialBridge::TcpSerialBridge(
 	bool debug) : server(tcpPort)
 {
 	WiFiManager wifiManager;
-	ssid = "SHC-" + WiFi.macAddress();
+	ssid = "SHC-" + getUniqueId();
 	this->outgoingStream = outgoingStream;
 	this->incomingStream = incomingStream;
 	this->debug = debug;


### PR DESCRIPTION
Bug was reported where `multiple definition of _Z11getUniqueIdv'` was shown.

Fix involves extracting the getUniqueId function to a .cpp file rather than the header.
Additionally replaced the direct call to `WiFi.macAddress();` in the ssid setting code, so that it uses the getUniqueId method and that id can be abstracted away from the implementation.