### PR TITLE
Fix return types for SHFastIO.h

### DIFF
--- a/src/SHFastIO.h
+++ b/src/SHFastIO.h
@@ -4,8 +4,8 @@
 
 class FastDigitalPin {
 private:
-	unsigned long bit = 0;
-	unsigned long port = 0;
+	uint32_t bit = 0;
+	uint32_t port = 0;
 	bool pinIsValid = false;
 public:
 


### PR DESCRIPTION
fix https://github.com/eCrowneEng/ESP-SimHub/issues/31

The return types for the ESPs are `unsigned long`s, which are equivalent to `uint32_t` for the current generations. 

Given that `uint32_t` was already tested to be working I'll switch to those. If you're reading this from the future, and something broke.. just fix this assumption. We're doing what we can with the information we have available right now :D