### PR TITLE
Updates ssd1306 lib to fix stretched OLED height

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -4,7 +4,7 @@ lib_deps =
 	adafruit/Adafruit LED Backpack Library@^1.1
 	adafruit/Adafruit NeoPixel@^1.10.5
 	adafruit/Adafruit PCD8544 Nokia 5110 LCD library@^2.0.1
-	adafruit/Adafruit SSD1306@1.1.2
+	adafruit/Adafruit SSD1306@2.5.9
 	adafruit/Adafruit WS2801 Library@1.1.1
 	#includes fixes for esp
 	https://github.com/9khil/LedControl#913cbcebb8ceea6783bb271d385d18b99c2d5e79

--- a/src/SHGLCD_I2COLED.h
+++ b/src/SHGLCD_I2COLED.h
@@ -7,9 +7,11 @@
 #include "SHGLCD_base.h"
 
 
+// When using a 0.98" OLED w/ an SSD1306 driver, the resolution will almost always be 128x64
+#define SCREEN_WIDTH 128 // OLED width
+#define SCREEN_HEIGHT 64 // OLED height 
 #define OLED_RESET 4
-
-Adafruit_SSD1306 glcd1(OLED_RESET);
+Adafruit_SSD1306 glcd1(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 Adafruit_SSD1306 * oled[] = { &glcd1 };
 
 class SHGLCD_I2COLED : public SHGLCD_Base


### PR DESCRIPTION
### What is this change
This is a fix to get layouts scaled correctly on OLED devices driven by a SSD1306.  Before this change, OLED layout content from Simhub was stretched vertically by 2x, and any pixel rendered with a y value of greater than 32 wasn't seen on screen. The fix updates the SSD1306 library and declares the OLED height and width on initialization.

### Details
The newer versions of the Adafruit SSD1306 library allows for screen declarations with screen height and screen widths to be defined, however 99% of the time the screen will be 128x64.  To best accommodate this, I wrote default values for these dimensions, with comments saying as much should users need to change them down the line.

### Changes
- `adafruit/Adafruit SSD1306` library declaration in `platformio.ini` updated to 2.5.9 (latest)
- new const declarations in `SHGLCD_I2COLED.h` for screen height and width.
- Initialization of screen object in `SHGLCD_I2COLED.h` updated