### PR TITLE
Fixes to pwm fans by @the-make-r; add LED brightness nanny code

### DIFF
--- a/lib/EspSimHub/TimerOne.h
+++ b/lib/EspSimHub/TimerOne.h
@@ -27,6 +27,7 @@ public:
 #endif
     }
 
+    // duty is 0-1023
     void pwm(char pin, unsigned int duty) __attribute__((always_inline))
     {
 #ifdef ESP32
@@ -41,9 +42,9 @@ public:
                 throw std::out_of_range("too many pwm channels");
             }
             ledcSetup(newChannel, frequency, 10);
+            ledcAttachPin(pin, newChannel);
             existingChannel = newChannel;
         }
-        // 10 bits resolution
         ledcWrite(existingChannel, duty);
 #endif
 #ifdef ESP8266

--- a/src/NeoPixelBusLEDs.h
+++ b/src/NeoPixelBusLEDs.h
@@ -16,6 +16,16 @@
 #define RIGHTTOLEFT 0
 #define TEST_MODE 1
 
+// LED BRIGHTNESS NANNY
+//  Think about why you want to go higher than this?
+//  is your power supply ready? are your eyes ready?, is your heat dissipation ready?
+//  https://learn.adafruit.com/sipping-power-with-neopixels/insights
+//  remember, if you don't have an external power supply, your board or USB may not be able
+//  to provide enough power.
+// luminance goes from 0-255, UPDATE AT YOUR OWN RISK
+#define LUMINANCE_LIMIT 150
+
+
 // The color order that your LED strip uses
 // https://github.com/Makuna/NeoPixelBus/wiki/Neo-Features
 #define colorSpec NeoGrbFeature // A three-element color in the order of Green, Red, and then Blue. This is used for SK6812(grb), WS2811, and WS2812.
@@ -113,6 +123,8 @@
 //  more than your device can provide, which can damage it. Start with lower numbers 
 //  ex: (50, 0, 0) is red and (100, 0, 0) is still red, just brighter
 //  See this: https://learn.adafruit.com/adafruit-neopixel-uberguide/powering-neopixels#estimating-power-requirements-2894486
+//
+// note: that this color is not limited by the luminance limit
 auto initialColor = RgbColor(120, 0, 0);
 
 
@@ -146,14 +158,13 @@ if (std::string(className).find(prefix) == 0) {
 
     if (TEST_MODE)
     {
-        neoLedStrip.SetLuminance(155);
         for (int i = 0; i < LED_COUNT; i++)
         {
             neoLedStrip.SetPixelColor(i, initialColor);
         }
         neoLedStrip.Show();
     }
-    neoLedStrip.SetLuminance(255);
+    neoLedStrip.SetLuminance(LUMINANCE_LIMIT);
 }
 
 void neoPixelBusRead()


### PR DESCRIPTION
This is a simpler version of:
https://github.com/eCrowneEng/ESP-SimHub/pull/42
by @the-make-r

basically adding a line: ledcAttachPin which is missing.

in theory this should fix the issue they were seeing. but I haven not thoroughly tested it.

Worst case scenario, this doesn't fix the issue (more things broken, not only this line). Best case scenario, this fixes the PWM issue for the ESP32.

additionally, I added a brightness limit to NeoPixelBusLEDs. This should help avoid burning some boards by an overly enthusiastic LED implementer.