### PR TITLE
Fix gamepad issue for esp8266

### DIFF
--- a/lib/ECrowneJoystick/ECrowneJoystick.cpp
+++ b/lib/ECrowneJoystick/ECrowneJoystick.cpp
@@ -1,7 +1,7 @@
-#include "USBHID.h"
 
 #if SOC_USB_OTG_SUPPORTED
 #if CONFIG_TINYUSB_HID_ENABLED
+#include "USBHID.h"
 
 #include <ECrowneJoystick.h>
 #include <Arduino.h>

--- a/lib/ECrowneJoystick/ECrowneJoystick.h
+++ b/lib/ECrowneJoystick/ECrowneJoystick.h
@@ -2,9 +2,8 @@
 
 #pragma once
 
-#include "USBHID.h"
-
 #if SOC_USB_OTG_SUPPORTED
+#include "USBHID.h"
 #if CONFIG_TINYUSB_HID_ENABLED
 #define MAX_BUTTONS 128
 


### PR DESCRIPTION
platformio is compiling the gamepad library without checking imports; it fails for esp8266 because there is an usbhid import outside the feature macro.